### PR TITLE
Unwanted calls to background-image url when url is empty or undefined

### DIFF
--- a/src/draggable-bg.js
+++ b/src/draggable-bg.js
@@ -42,9 +42,13 @@ angular.module('chieffancypants.draggableBg', [])
         // rerun all this if imgSrc changes.  Particularly useful when imgSrc
         // is only set after some kind of XHR comes back
         scope.$watch('imgSrc', function (newVal) {
-          element.css('background-image', 'url(' + newVal + ')');
-          element.addClass('draggable-bg');
-          setImageDimensions();
+          if (newVal) {
+            element.css('background-image', 'url(' + newVal + ')');
+            element.addClass('draggable-bg');
+            setImageDimensions();
+          } else {
+            element.css('background-image', 'none');
+          }
         });
 
         element.on('mousedown', function (event) {


### PR DESCRIPTION
I was having an issue with an unnecessary GET request to the root url of the site when `imgSrc` was undefined or empty.

CSS style applied on the element with bg-draggable was:

```css
background-image: url((unknown));
```

I am presenting here a simple fix for scope.$watch which will set the `background-image` CSS style only if the url of an image is defined.

```js
scope.$watch('imgSrc', function (newVal) {
    if (newVal) {
        element.css('background-image', 'url(' + newVal + ')');
        element.addClass('draggable-bg');
        setImageDimensions();
    } else {
        element.css('background-image', 'none');
    }
});
```